### PR TITLE
Updated Sanger quality range

### DIFF
--- a/reads-utils/guess-encoding.py
+++ b/reads-utils/guess-encoding.py
@@ -7,7 +7,7 @@ import sys
 import optparse
 
 RANGES = {
-    'Sanger': (33, 73),
+    'Sanger': (33, 93),
     'Solexa': (59, 104),
     'Illumina-1.3': (64, 104),
     'Illumina-1.5': (67, 104)


### PR DESCRIPTION
From the wiki

> Sanger format can encode a Phred quality score from 0 to 93 using ASCII 33 to 126 (although in raw read data the Phred quality score rarely exceeds 60

60 + 33 = 93. Using 73 means some high quality Sanger encoded data will not be determined (I had this issue having data with quality scores above 40).
