### PR TITLE
Modify the output format to ease parsing

### DIFF
--- a/reads-utils/guess-encoding.py
+++ b/reads-utils/guess-encoding.py
@@ -102,8 +102,7 @@ def main():
     if err_exit:
         sys.exit(1)
     else:
-        print("{}\t{}\t{}".format(valid, gmin, gmax),
-              file=sys.stderr)
+        print("{}\t{}\t{}".format(",".join(valid), gmin, gmax))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Change the first column containing the guessed encodings to a
  comma-delimited list. Partially reverts output format changes
  introduced by 95adaa7. Resolves #19 (see discussion in #17).

- Direct the main output to STDOUT, leaving comments or errors on
  STDERR. This was originally intended, but neglected, in 95adaa7.